### PR TITLE
Suggested: generalizes `AsResult` for any `Effect`

### DIFF
--- a/specs2/src/main/scala/cats/effect/specs2/CatsEffect.scala
+++ b/specs2/src/main/scala/cats/effect/specs2/CatsEffect.scala
@@ -16,13 +16,21 @@
 
 package cats.effect.specs2
 
-import cats.effect.{ContextShift, IO, Timer}
+import cats.effect.Effect
+import cats.effect.syntax.effect._
+import org.specs2.execute.{AsResult, Failure, Result}
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+import scala.language.higherKinds
 
-trait CatsEffect extends CatsEffectGeneric {
-  private val executionContext: ExecutionContext = ExecutionContext.global
+trait CatsEffect {
 
-  implicit val ioContextShift: ContextShift[IO] = IO.contextShift(executionContext)
-  implicit val ioTimer: Timer[IO] = IO.timer(executionContext)
+  protected val Timeout: Duration = 10.seconds
+
+  implicit def effectAsResult[F[_]: Effect, R](implicit R: AsResult[R]): AsResult[F[R]] = new AsResult[F[R]] {
+    def asResult(t: => F[R]): Result =
+      t.toIO.unsafeRunTimed(Timeout)
+        .map(R.asResult(_))
+        .getOrElse(Failure(s"expectation timed out after $Timeout"))
+  }
 }

--- a/specs2/src/main/scala/cats/effect/specs2/CatsEffectGeneric.scala
+++ b/specs2/src/main/scala/cats/effect/specs2/CatsEffectGeneric.scala
@@ -16,13 +16,21 @@
 
 package cats.effect.specs2
 
-import cats.effect.{ContextShift, IO, Timer}
+import cats.effect.Effect
+import cats.effect.syntax.effect._
+import org.specs2.execute.{AsResult, Failure, Result}
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+import scala.language.higherKinds
 
-trait CatsEffect extends CatsEffectGeneric {
-  private val executionContext: ExecutionContext = ExecutionContext.global
+trait CatsEffectGeneric {
 
-  implicit val ioContextShift: ContextShift[IO] = IO.contextShift(executionContext)
-  implicit val ioTimer: Timer[IO] = IO.timer(executionContext)
+  protected val Timeout: Duration = 10.seconds
+
+  implicit def effectAsResult[F[_] : Effect, R](implicit R: AsResult[R]): AsResult[F[R]] = new AsResult[F[R]] {
+    def asResult(t: => F[R]): Result =
+      t.toIO.unsafeRunTimed(Timeout)
+        .map(R.asResult(_))
+        .getOrElse(Failure(s"expectation timed out after $Timeout"))
+  }
 }

--- a/specs2/src/main/scala/cats/effect/specs2/CatsEffectGeneric.scala
+++ b/specs2/src/main/scala/cats/effect/specs2/CatsEffectGeneric.scala
@@ -27,7 +27,7 @@ trait CatsEffectGeneric {
 
   protected val Timeout: Duration = 10.seconds
 
-  implicit def effectAsResult[F[_] : Effect, R](implicit R: AsResult[R]): AsResult[F[R]] = new AsResult[F[R]] {
+  implicit def effectAsResult[F[_]: Effect, R](implicit R: AsResult[R]): AsResult[F[R]] = new AsResult[F[R]] {
     def asResult(t: => F[R]): Result =
       t.toIO.unsafeRunTimed(Timeout)
         .map(R.asResult(_))

--- a/specs2/src/main/scala/cats/effect/specs2/CatsIO.scala
+++ b/specs2/src/main/scala/cats/effect/specs2/CatsIO.scala
@@ -16,21 +16,13 @@
 
 package cats.effect.specs2
 
-import cats.effect.Effect
-import cats.effect.syntax.effect._
-import org.specs2.execute.{AsResult, Failure, Result}
+import cats.effect.{ContextShift, IO, Timer}
 
-import scala.concurrent.duration._
-import scala.language.higherKinds
+import scala.concurrent.ExecutionContext
 
-trait CatsEffectGeneric {
+trait CatsIO extends CatsEffect {
+  private val executionContext: ExecutionContext = ExecutionContext.global
 
-  protected val Timeout: Duration = 10.seconds
-
-  implicit def effectAsResult[F[_]: Effect, R](implicit R: AsResult[R]): AsResult[F[R]] = new AsResult[F[R]] {
-    def asResult(t: => F[R]): Result =
-      t.toIO.unsafeRunTimed(Timeout)
-        .map(R.asResult(_))
-        .getOrElse(Failure(s"expectation timed out after $Timeout"))
-  }
+  implicit val ioContextShift: ContextShift[IO] = IO.contextShift(executionContext)
+  implicit val ioTimer: Timer[IO] = IO.timer(executionContext)
 }


### PR DESCRIPTION
Updates `cats-effect-testing-specs2`:

Extracts `ioAsResult` from `CatsEffect` into `CatsEffectGeneric` and generalizes it in the way it can accept any type which implements `Effect` type class.

This change would allow to test some other effect types, like `Monix`'s `Task`.

The `ioAsResult` method is extracted because it might not have any sense to keep `ioContextShift` and `ioTimer` in scope for other effect types.
