### PR TITLE
Add tagless instance of CheckerAsserting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,6 +46,18 @@ lazy val specs2 = project
       "org.typelevel" %% "cats-effect" % catsEffectVersion,
       "org.specs2"    %% "specs2-core" % "4.7.1"))
 
+lazy val `scalatest-scalacheck` = project
+  .in(file("scalatest-scalacheck"))
+  .settings(
+    name := "cats-effect-testing-scalatest-scalacheck",
+
+    libraryDependencies ++= Seq(
+      "org.typelevel" %% "cats-effect" % catsEffectVersion,
+      "org.scalacheck" %% "scalacheck" % "1.14.2",
+      "org.scalatestplus" %% "scalatestplus-scalacheck" % "3.1.0.0-RC2"
+    )
+  )
+  .dependsOn(scalatest % Test)
 
 lazy val scalatest = project
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,9 @@ lazy val `scalatest-scalacheck` = project
       "org.typelevel" %% "cats-effect" % catsEffectVersion,
       "org.scalacheck" %% "scalacheck" % "1.14.2",
       "org.scalatestplus" %% "scalacheck-1-14" % "3.1.0.0"
-    )
+    ),
+
+    mimaPreviousArtifacts := mimaPreviousArtifacts.value - ("com.codecommit" %% name.value % "0.3.0")
   )
   .dependsOn(scalatest)
 

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ val catsEffectVersion = "2.0.0"
 
 lazy val root = project
   .in(file("."))
-  .aggregate(specs2, utest, minitest, scalatest)
+  .aggregate(specs2, utest, minitest, scalatest, `scalatest-scalacheck`)
   .settings(noPublishSettings)
 
 lazy val specs2 = project
@@ -54,7 +54,7 @@ lazy val `scalatest-scalacheck` = project
     libraryDependencies ++= Seq(
       "org.typelevel" %% "cats-effect" % catsEffectVersion,
       "org.scalacheck" %% "scalacheck" % "1.14.2",
-      "org.scalatestplus" %% "scalacheck-1.14" % "3.1.0.0"
+      "org.scalatestplus" %% "scalacheck-1-14" % "3.1.0.0"
     )
   )
   .dependsOn(scalatest)

--- a/build.sbt
+++ b/build.sbt
@@ -54,7 +54,7 @@ lazy val `scalatest-scalacheck` = project
     libraryDependencies ++= Seq(
       "org.typelevel" %% "cats-effect" % catsEffectVersion,
       "org.scalacheck" %% "scalacheck" % "1.14.2",
-      "org.scalatestplus" %% "scalatestplus-scalacheck" % "3.1.0.0-RC2"
+      "org.scalatestplus" %% "scalacheck-1.14" % "3.1.0.0"
     )
   )
   .dependsOn(scalatest)

--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,7 @@ lazy val `scalatest-scalacheck` = project
       "org.scalatestplus" %% "scalatestplus-scalacheck" % "3.1.0.0-RC2"
     )
   )
-  .dependsOn(scalatest % Test)
+  .dependsOn(scalatest)
 
 lazy val scalatest = project
   .settings(

--- a/scalatest-scalacheck/src/main/scala/cats/effect/scalatest/scalacheck/EffectCheckerAsserting.scala
+++ b/scalatest-scalacheck/src/main/scala/cats/effect/scalatest/scalacheck/EffectCheckerAsserting.scala
@@ -1,0 +1,43 @@
+package cats.effect.scalatest.scalacheck
+
+import cats.effect.Effect
+import org.scalactic.source
+import org.scalatest.exceptions._
+import org.scalatestplus.scalacheck.CheckerAsserting
+
+class EffectCheckerAsserting[F[_], A](implicit F: Effect[F])
+    extends CheckerAsserting.CheckerAssertingImpl[F[A]] {
+
+  override type Result = F[Unit]
+
+  override def succeed(result: F[A]): (Boolean, Option[Throwable]) =
+    F.toIO(result)
+      .attempt
+      .unsafeRunSync()
+      .fold(e => (false, Some(e)), _ => (true, None))
+
+  override def indicateSuccess(message: => String): Result = F.unit
+
+  override def indicateFailure(
+      messageFun: StackDepthException => String,
+      undecoratedMessage: => String,
+      scalaCheckArgs: List[Any],
+      scalaCheckLabels: List[String],
+      optionalCause: Option[Throwable],
+      pos: source.Position
+  ): Result = {
+    val error = new GeneratorDrivenPropertyCheckFailedException(
+      messageFun,
+      optionalCause,
+      pos,
+      None,
+      undecoratedMessage,
+      scalaCheckArgs,
+      None,
+      scalaCheckLabels
+    )
+
+    F.raiseError(error)
+  }
+
+}

--- a/scalatest-scalacheck/src/main/scala/cats/effect/scalatest/scalacheck/EffectCheckerAsserting.scala
+++ b/scalatest-scalacheck/src/main/scala/cats/effect/scalatest/scalacheck/EffectCheckerAsserting.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Daniel Spiewak
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package cats.effect.scalatest.scalacheck
 
 import cats.effect.Effect

--- a/scalatest-scalacheck/src/test/scala/cats/effect/scalatest/scalacheck/IOTest.scala
+++ b/scalatest-scalacheck/src/test/scala/cats/effect/scalatest/scalacheck/IOTest.scala
@@ -1,0 +1,56 @@
+package cats.effect.scalatest.scalacheck
+
+import cats.data.EitherT
+import cats.effect.scalatest.AsyncIOSpec
+import cats.effect.{IO, Sync}
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.{CheckerAsserting, ScalaCheckPropertyChecks}
+
+class IOTest extends AsyncIOSpec with Matchers with ScalaCheckPropertyChecks {
+
+  "IO assertions" - {
+
+    "Assert success" in {
+      forAll { (l1: List[Int], l2: List[Int]) =>
+        IO.delay(l1.size + l2.size shouldBe (l1 ::: l2).size)
+      }
+    }
+
+    "Assert exception" in {
+      val check: IO[Unit] = forAll { (l1: List[Int], l2: List[Int]) =>
+        IO.delay(l1.size + l2.size shouldBe -1)
+      }
+
+      check.assertThrows[Exception]
+    }
+
+    implicit def ioCheckingAsserting[A]: CheckerAsserting[IO[A]] { type Result = IO[Unit] } =
+      new EffectCheckerAsserting
+
+  }
+
+  "EitherT[IO, Throwable, A] assertions" - {
+
+    type Eff[A] = EitherT[IO, Throwable, A]
+
+    "Assert success" in {
+      val check = forAll { (l1: List[Int], l2: List[Int]) =>
+        Sync[Eff].delay(l1.size + l2.size shouldBe (l1 ::: l2).size)
+      }
+
+      check.leftSemiflatMap[Unit](IO.raiseError).merge.assertNoException
+    }
+
+    "Assert exception" in {
+      val check = forAll { (l1: List[Int], l2: List[Int]) =>
+        Sync[Eff].delay(l1.size + l2.size shouldBe -1)
+      }
+
+      check.leftSemiflatMap[Unit](IO.raiseError[Unit]).merge.assertThrows[Exception]
+    }
+
+    implicit def checkingAsserting[A]: CheckerAsserting[Eff[A]] { type Result = Eff[Unit] } =
+      new EffectCheckerAsserting
+  }
+
+}

--- a/scalatest-scalacheck/src/test/scala/cats/effect/scalatest/scalacheck/IOTest.scala
+++ b/scalatest-scalacheck/src/test/scala/cats/effect/scalatest/scalacheck/IOTest.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Daniel Spiewak
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package cats.effect.scalatest.scalacheck
 
 import cats.data.EitherT
@@ -8,7 +24,7 @@ import org.scalatestplus.scalacheck.{CheckerAsserting, ScalaCheckPropertyChecks}
 
 class IOTest extends AsyncIOSpec with Matchers with ScalaCheckPropertyChecks {
 
-  "IO assertions" - {
+  "Scalacheck IO assertions" - {
 
     "Assert success" in {
       forAll { (l1: List[Int], l2: List[Int]) =>
@@ -29,7 +45,7 @@ class IOTest extends AsyncIOSpec with Matchers with ScalaCheckPropertyChecks {
 
   }
 
-  "EitherT[IO, Throwable, A] assertions" - {
+  "Scalacheck EitherT[IO, Throwable, A] assertions" - {
 
     type Eff[A] = EitherT[IO, Throwable, A]
 


### PR DESCRIPTION
This PR adds a tagless instance of `org.scalatestplus.scalacheck.CheckerAsserting`. It allows using effect inside `forAll` closure.

There are several scenarios when `forAll` should return an effect. For example, an integration test that relies on the real effect:

Service algebra:
```scala
class Service[F[_]] {
  def verify(username: String, password: String): F[Boolean]
}
```

Original test:
```scala
class Test extends Matchers with ScalaCheckPropertyChecks {
  type Eff[A] = Either[IO, AppError, A]

  "Service" should {
    "verify a user" in withService { service =>
       Sync[Eff].delay { 
         forAll { (user: String, pwd: String) =>
           service.verify(username, password).toIO.runSyncUnsafe
         }
      }
    }
  }

  def withService[A](fa: Service[Eff] => Eff[A]): Eff[Unit] = 
    fa(new Service(....)).toIO.void.runSyncUnsafe
}
```

Test with a custom CheckerAsserting:
```scala
class Test extends Matchers with ScalaCheckPropertyChecks {
  type Eff[A] = Either[IO, AppError, A]

  "Service" should {
    "verify a user" in withService { service =>
       forAll { (user: String, pwd: String) => 
         service.verify(username, password) 
      }
    }
  }

  def withService[A](fa: Service[Eff] => Eff[A]): Eff[Unit] = 
    fa(new Service(....)).toIO.void.runSyncUnsafe

  implicit def checkingAsserting[A]: CheckerAsserting[Eff[A]] { type Result = Eff[Unit] } =
    new EffectCheckerAsserting
}
```

As a result, it's not necessary to wrap `forAll` into `Sync[Eff].delay` and check is being evaluated under the hood.

What do you think @djspiewak? Does it make sense to include this in the library?