### PR TITLE
Attempt at adding fixture

### DIFF
--- a/minitest/src/main/scala/cats/effect/minitest/BaseIOTestSuite.scala
+++ b/minitest/src/main/scala/cats/effect/minitest/BaseIOTestSuite.scala
@@ -18,11 +18,13 @@ package cats.effect.minitest
 
 import scala.concurrent.ExecutionContext
 
+import cats.Eval
 import cats.effect.{ContextShift, IO, Timer}
 import minitest.api._
 
 
-private[effect] abstract class BaseIOTestSuite[Ec <: ExecutionContext] extends AbstractTestSuite with Asserts {
+private[effect] abstract class BaseIOTestSuite[A, Ec <: ExecutionContext] extends AbstractTestSuite with Asserts {
+
   protected def makeExecutionContext(): Ec
 
   private[effect] lazy val executionContext: Ec = makeExecutionContext()
@@ -31,20 +33,47 @@ private[effect] abstract class BaseIOTestSuite[Ec <: ExecutionContext] extends A
   implicit def ioContextShift: ContextShift[IO] = IO.contextShift(executionContext)
   implicit def ioTimer: Timer[IO] = IO.timer(executionContext)
 
-  protected[effect] def mkSpec(name: String, ec: Ec, io: => IO[Unit]): TestSpec[Unit, Unit]
+  protected[effect] def mkSpec(name: String, ec: Ec, io: A => IO[Unit]): TestSpec[A, Unit]
 
-  def test(name: String)(f: => IO[Unit]): Unit =
+  private[this] def alreadyInitializedError(str: String): Error =
+    new AssertionError(s"Cannot define $str after TestSuite was initialized")
+
+  private[this] var fixture: Option[Eval[A]] = None
+  private[this] var tearDownF: A => IO[Unit] = _ => IO.pure(())
+
+  def setup(f: => IO[A]): Unit =
     synchronized {
-      if (isInitialized) throw new AssertionError("Cannot define new tests after TestSuite was initialized")
+      if (isInitialized) throw alreadyInitializedError("setup")
+      fixture = Some(Eval.later(f.unsafeRunSync))
+    }
+
+  def tearDown(a: A => IO[Unit]): Unit =
+    synchronized {
+      if (isInitialized) throw alreadyInitializedError("tear down")
+      tearDownF = a
+    }
+
+  def test(name: String)(f: A => IO[Unit]): Unit =
+    synchronized {
+      if (isInitialized) throw alreadyInitializedError("new tests")
       propertiesSeq :+= mkSpec(name, executionContext, f)
     }
 
-  lazy val properties: Properties[_] =
+   lazy val properties: Properties[_] =
     synchronized {
       if (!isInitialized) isInitialized = true
-      Properties[Unit](() => (), _ => Void.UnitRef, () => (), () => (), propertiesSeq)
+      Properties[A](
+        () => fixture
+          .map(_.value)
+          .getOrElse(throw new AssertionError("could not create fixture")),
+        a => tearDownF(a).unsafeRunSync,
+        () => (),
+        () => (),
+        propertiesSeq
+      )
     }
 
-  private[this] var propertiesSeq = Vector.empty[TestSpec[Unit, Unit]]
+
+  private[this] var propertiesSeq = Vector.empty[TestSpec[A, Unit]]
   private[this] var isInitialized = false
 }


### PR DESCRIPTION
Not particularly happy with this, but thought I'd open a PR for some guidance.

I've got quite a few use cases where I have some `F[A]` which I'd like to share over several tests. Some thoughts:

- `minitest` favours a single keyword `test` so I've mirrored it here
- I'd like to rename the current suites to be prefixed with `Simple` to mirror `minitest`
- I don't know the last time I used `super`