### PR TITLE
Add explicit support for timeout to UnsafeRun

### DIFF
--- a/core/shared/src/main/scala/cats/effect/testing/UnsafeRun.scala
+++ b/core/shared/src/main/scala/cats/effect/testing/UnsafeRun.scala
@@ -17,12 +17,14 @@
 package cats.effect
 package testing
 
+import scala.annotation.nowarn
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 
 trait UnsafeRun[F[_]] {
-  def unsafeToFuture[A](fa: F[A]): Future[A] = unsafeToFuture(fa, None)
-  def unsafeToFuture[A](fa: F[A], timeout: Option[FiniteDuration]): Future[A]
+  def unsafeToFuture[A](fa: F[A]): Future[A]
+  def unsafeToFuture[A](fa: F[A], @nowarn("msg=never used") timeout: Option[FiniteDuration]): Future[A]
+    = unsafeToFuture(fa) // For binary compatibility
 }
 
 object UnsafeRun {
@@ -32,11 +34,11 @@ object UnsafeRun {
   implicit object unsafeRunForCatsIO extends UnsafeRun[IO] {
     import unsafe.implicits.global
 
-    override def unsafeToFuture[A](fa: IO[A]): Future[A] =
-      super.unsafeToFuture(fa)
+    override def unsafeToFuture[A](ioa: IO[A]): Future[A] =
+      unsafeToFuture(ioa, None)
 
     // TODO is it worth isolating runtimes between test runs?
-    def unsafeToFuture[A](ioa: IO[A], timeout: Option[FiniteDuration]): Future[A] =
+    override def unsafeToFuture[A](ioa: IO[A], timeout: Option[FiniteDuration]): Future[A] =
       timeout.fold(ioa)(ioa.timeout).unsafeToFuture()
   }
 }

--- a/scalatest/shared/src/main/scala/cats/effect/testing/scalatest/CatsResource.scala
+++ b/scalatest/shared/src/main/scala/cats/effect/testing/scalatest/CatsResource.scala
@@ -18,7 +18,6 @@ package cats.effect.testing
 package scalatest
 
 import cats.effect.{Async, Deferred, Resource, Sync}
-import cats.effect.syntax.all._
 import cats.syntax.all._
 
 import org.scalatest.{BeforeAndAfterAll, FixtureAsyncTestSuite, FutureOutcome, Outcome}

--- a/specs2/shared/src/main/scala/cats/effect/testing/specs2/CatsResource.scala
+++ b/specs2/shared/src/main/scala/cats/effect/testing/specs2/CatsResource.scala
@@ -19,7 +19,6 @@ package specs2
 
 import cats.effect.{Async, Deferred, Resource, Spawn, Sync}
 import cats.syntax.all._
-import cats.effect.syntax.all._
 
 import org.specs2.specification.BeforeAfterAll
 

--- a/utest/shared/src/main/scala/cats/effect/testing/utest/IOTestSuite.scala
+++ b/utest/shared/src/main/scala/cats/effect/testing/utest/IOTestSuite.scala
@@ -17,14 +17,11 @@
 package cats.effect.testing
 package utest
 
-import cats.effect.Temporal
-import cats.effect.syntax.all._
-
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.reflect.ClassTag
 
-abstract class EffectTestSuite[F[_]: Temporal: UnsafeRun](implicit Tag: ClassTag[F[Any]])
+abstract class EffectTestSuite[F[_]: UnsafeRun](implicit Tag: ClassTag[F[Any]])
     extends _root_.utest.TestSuite {
 
   protected def timeout: FiniteDuration = 10.seconds

--- a/utest/shared/src/main/scala/cats/effect/testing/utest/IOTestSuite.scala
+++ b/utest/shared/src/main/scala/cats/effect/testing/utest/IOTestSuite.scala
@@ -17,11 +17,15 @@
 package cats.effect.testing
 package utest
 
+import cats.effect.Temporal
+
+import scala.annotation.nowarn
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.reflect.ClassTag
 
-abstract class EffectTestSuite[F[_]: UnsafeRun](implicit Tag: ClassTag[F[Any]])
+@nowarn("msg=parameter value evidence\\$1 in class EffectTestSuite is never used")
+abstract class EffectTestSuite[F[_]: Temporal: UnsafeRun](implicit Tag: ClassTag[F[Any]])
     extends _root_.utest.TestSuite {
 
   protected def timeout: FiniteDuration = 10.seconds

--- a/utest/shared/src/main/scala/cats/effect/testing/utest/IOTestSuite.scala
+++ b/utest/shared/src/main/scala/cats/effect/testing/utest/IOTestSuite.scala
@@ -32,7 +32,7 @@ abstract class EffectTestSuite[F[_]: Temporal: UnsafeRun](implicit Tag: ClassTag
 
   override def utestWrap(path: Seq[String], runBody: => Future[Any])(implicit ec: ExecutionContext): Future[Any] = {
     runBody flatMap {
-      case Tag(io) => UnsafeRun[F].unsafeToFuture(io.timeout(timeout))
+      case Tag(io) => UnsafeRun[F].unsafeToFuture(io, Some(timeout))
       case other if allowNonIOTests => Future.successful(other)
       case other => throw new RuntimeException(s"Test body must return an IO value. Got $other")
     }


### PR DESCRIPTION
This PR adds an an explicit timeout parameter to `UnsafeRun`. This solves the annoying problem where your test times out but the `IO` is not cancelled! Some of the frameworks had already implemented this. This is now all condensed.