### PR TITLE
Avoid non-JS compatible APIs for ScalaTest

### DIFF
--- a/scalatest/shared/src/main/scala/cats/effect/testing/scalatest/AsyncIOSpec.scala
+++ b/scalatest/shared/src/main/scala/cats/effect/testing/scalatest/AsyncIOSpec.scala
@@ -21,9 +21,7 @@ import org.scalatest.AsyncTestSuite
 
 trait AsyncIOSpec extends AssertingSyntax with EffectTestSupport { asyncTestSuite: AsyncTestSuite =>
 
-  implicit val ioRuntime: IORuntime = {
-    val (scheduler, sd) = IORuntime.createDefaultScheduler()
+  implicit val ioRuntime: IORuntime =
+    IORuntime(executionContext, executionContext, IORuntime.global.scheduler, () => (), IORuntimeConfig())
 
-    IORuntime(executionContext, executionContext, scheduler, sd, IORuntimeConfig())
-  }
 }


### PR DESCRIPTION
Not sure if this is too hacky, but this is working on both JVM and JS in https://github.com/circe/circe-fs2/pull/272. The `createDefaultScheduler` doesn't work on Scala.js.

The alternative is a full cross, or maybe an upstream PR to CE itself.