### PR TITLE
Experimenting with time in specs2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ ThisBuild / scmInfo := Some(
     url("https://github.com/djspiewak/cats-effect-testing"),
     "git@github.com:djspiewak/cats-effect-testing.git"))
 
-val CatsEffectVersion = "3.2.5"
+val CatsEffectVersion = "3.3-7-579f468"
 
 lazy val root = project
   .in(file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -76,7 +76,9 @@ lazy val specs2 = crossProject(JSPlatform, JVMPlatform)
   .dependsOn(core)
   .settings(
     name := "cats-effect-testing-specs2",
-    libraryDependencies += ("org.specs2" %%% "specs2-core" % "4.12.3").cross(CrossVersion.for3Use2_13))
+    libraryDependencies ++= Seq(
+      "org.typelevel" %%% "cats-effect-testkit" % CatsEffectVersion,
+      ("org.specs2"   %%% "specs2-core"         % "4.12.3").cross(CrossVersion.for3Use2_13)))
 
 lazy val scalatest = crossProject(JSPlatform, JVMPlatform)
   .in(file("scalatest"))

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@
 
 name := "cats-effect-testing"
 
-ThisBuild / baseVersion := "1.3"
+ThisBuild / baseVersion := "1.4"
 ThisBuild / strictSemVer := true
 
 ThisBuild / organization := "org.typelevel"

--- a/minitest/shared/src/main/scala/cats/effect/testing/minitest/DeterministicIOTestSuite.scala
+++ b/minitest/shared/src/main/scala/cats/effect/testing/minitest/DeterministicIOTestSuite.scala
@@ -48,7 +48,7 @@ abstract class DeterministicIOTestSuite extends BaseIOTestSuite[TestContext] {
         unsafe.IORuntime(ec, ec, scheduler, () => (), unsafe.IORuntimeConfig())
 
       val f = io.unsafeToFuture()
-      ec.tick(365.days)
+      ec.tickAll()
       f.value match {
         case Some(value) => value.get
         case None => throw new RuntimeException(

--- a/utest/shared/src/main/scala/cats/effect/testing/utest/DeterministicIOTestSuite.scala
+++ b/utest/shared/src/main/scala/cats/effect/testing/utest/DeterministicIOTestSuite.scala
@@ -46,7 +46,7 @@ abstract class DeterministicIOTestSuite extends TestSuite {
     runBody.flatMap {
       case io: IO[Any] =>
         val f = io.unsafeToFuture()
-        testContext.tickAll(365.days)
+        testContext.tickAll()
         assert(testContext.state.tasks.isEmpty)
         f.value match {
           case Some(_) => f


### PR DESCRIPTION
Fixes #192 

You can see an example of a proposed API within. This leans a bit on the Specs2 matcher support, so it might not make sense for the other frameworks, but it's a starting point.