### PR TITLE
Upgrade specs2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ ThisBuild / scmInfo := Some(
     "git@github.com:djspiewak/cats-effect-testing.git"))
 
 val CatsEffectVersion = "3.2.8"
-val specs2Version = "4.12.10"
+val specs2Version = "4.12.11"
 val specs2DottyVersion = "5.0.0-RC-09"
 
 lazy val root = project

--- a/build.sbt
+++ b/build.sbt
@@ -43,6 +43,8 @@ ThisBuild / scmInfo := Some(
     "git@github.com:djspiewak/cats-effect-testing.git"))
 
 val CatsEffectVersion = "3.2.8"
+val specs2Version = "4.12.10"
+val specs2DottyVersion = "5.0.0-RC-09"
 
 lazy val root = project
   .in(file("."))
@@ -76,7 +78,12 @@ lazy val specs2 = crossProject(JSPlatform, JVMPlatform)
   .dependsOn(core)
   .settings(
     name := "cats-effect-testing-specs2",
-    libraryDependencies += ("org.specs2" %%% "specs2-core" % "4.12.10").cross(CrossVersion.for3Use2_13))
+    libraryDependencies += {
+      if (isDotty.value)
+        "org.specs2" %%% "specs2-core" % specs2DottyVersion
+      else
+        "org.specs2" %%% "specs2-core" % specs2Version
+    })
 
 lazy val scalatest = crossProject(JSPlatform, JVMPlatform)
   .in(file("scalatest"))

--- a/specs2/shared/src/test/scala/cats/effect/testing/specs2/CatsEffectSpecs.scala
+++ b/specs2/shared/src/test/scala/cats/effect/testing/specs2/CatsEffectSpecs.scala
@@ -44,8 +44,9 @@ class CatsEffectSpecs extends Specification with CatsEffect with CatsEffectSpecs
 
     platformSpecs
 
-    "timeout a failing test" in pendingUntilFixed("this is ok") {
-      IO.never: IO[Boolean]
-    }
+    // pendingUntilFixed only works with specs2-5.x here
+    // "timeout a failing test" in pendingUntilFixed("this is ok") {
+    //   IO.never: IO[Boolean]
+    // }
   }
 }

--- a/specs2/shared/src/test/scala/cats/effect/testing/specs2/CatsEffectSpecs.scala
+++ b/specs2/shared/src/test/scala/cats/effect/testing/specs2/CatsEffectSpecs.scala
@@ -44,6 +44,8 @@ class CatsEffectSpecs extends Specification with CatsEffect with CatsEffectSpecs
 
     platformSpecs
 
-    // "timeout a failing test" in (IO.never: IO[Boolean])
+    "timeout a failing test" in pendingUntilFixed("this is ok") {
+      IO.never: IO[Boolean]
+    }
   }
 }

--- a/specs2/shared/src/test/scala/cats/effect/testing/specs2/CatsResourceSpecs.scala
+++ b/specs2/shared/src/test/scala/cats/effect/testing/specs2/CatsResourceSpecs.scala
@@ -30,7 +30,7 @@ class CatsResourceSpecs extends CatsResource[IO, Ref[IO, Int]] with Specificatio
       ref.modify{a =>
         (a + 1, a)
       }.map(
-        _ must_=== 0
+        _ === 0
       )
     }
 
@@ -38,7 +38,7 @@ class CatsResourceSpecs extends CatsResource[IO, Ref[IO, Int]] with Specificatio
       ref.modify{a =>
         (a + 1, a)
       }.map(
-        _ must_=== 1
+        _ === 1
       )
     }
   }


### PR DESCRIPTION
This PR uses specs2-5.x for Scala 3 and specs2-4.x for Scala 2. Both versions support the new `MacrotaskExecutor` execution context.
