### PR TITLE
Convert ioRuntime to lazy val

### DIFF
--- a/scalatest/shared/src/main/scala/cats/effect/testing/scalatest/AsyncIOSpec.scala
+++ b/scalatest/shared/src/main/scala/cats/effect/testing/scalatest/AsyncIOSpec.scala
@@ -27,7 +27,7 @@ import org.scalatest.time.Span
 
 trait AsyncIOSpec extends AssertingSyntax with EffectTestSupport with RuntimePlatform { asyncTestSuite: AsyncTestSuite =>
 
-  implicit val ioRuntime: IORuntime = createIORuntime(executionContext)
+  implicit lazy val ioRuntime: IORuntime = createIORuntime(executionContext)
 
   implicit def ioRetrying[T]: Retrying[IO[T]] = new Retrying[IO[T]] {
     override def retry(timeout: Span, interval: Span, pos: Position)(fun: => IO[T]): IO[T] =

--- a/scalatest/shared/src/test/scala/cats/effect/testing/scalatest/IOTestAsyncFlatSpecLike.scala
+++ b/scalatest/shared/src/test/scala/cats/effect/testing/scalatest/IOTestAsyncFlatSpecLike.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.testing.scalatest
+
+import cats.effect.IO
+import org.scalatest.freespec.AsyncFreeSpecLike
+import org.scalatest.matchers.should.Matchers
+
+class IOSpecAsyncFlatSpecTests extends AsyncIOSpec with AsyncFreeSpecLike with Matchers {
+
+  "Asserting Syntax " - {
+    "IO Asserting" in {
+      IO(1).asserting(_ shouldBe 1)
+    }
+  }
+
+  "Effect assertions" - {
+    "IO Assertion" in {
+      IO(1 shouldBe 1)
+    }
+  }
+}
+


### PR DESCRIPTION
By making ioRuntime a lazy val in the AsyncIOSpec the order in which the trait are mixed in the trait does not matter as much as it is current.

Currently, by mixing AsyncIO trait BEFORE another trait/abstract class with a executionContext the execution fails with a Null Pointer Exception.
The following code shows this issue:

```scala
import cats.effect.testing.scalatest.AsyncIOSpec
import org.scalatest.flatspec.AsyncFlatSpecLike
import org.scalatest.matchers.should.Matchers
import cats.effect.IO

class Test extends AsyncFlatSpecLike with AsyncIOSpec with  Matchers {
  "A test" should "fail" in {
    IO { 1 shouldBe 2 }
  }
}
new Test().execute() // Test fails as expected

class TestFailure extends AsyncIOSpec with AsyncFlatSpecLike with  Matchers {
  "A test" should "fail" in {
    IO { 1 shouldBe 2 }
  }
}

new TestFailure().execute() // Fails with an NPE
```

I think that this change could prevent some mistake made when mixing multiple trait inside ScalaTest, I however don't have enough visibility on the impact caused by this change, and what would happen if multiple ExecutionContext were available when creating the `ioRuntime`.

Feel free to comment/reject/discuss. The workaround/fix is pretty easy to implement when using the library, but the NPE stacktrace is pretty confusing and not easy to debug when running the tests.