### PR TITLE
assertion-for-exception-messages

### DIFF
--- a/scalatest/shared/src/main/scala/cats/effect/testing/scalatest/AssertingSyntax.scala
+++ b/scalatest/shared/src/main/scala/cats/effect/testing/scalatest/AssertingSyntax.scala
@@ -63,5 +63,32 @@ trait AssertingSyntax {
             fail(s"Expected an exception of type ${ct.runtimeClass.getName} but got a result: $a")
           )
       }
+
+    /**
+     * Asserts that the `F[A]` fails with an exception of type `E` and an expected error message.
+     */
+    def assertThrowsWithMessage[E <: Throwable](expectedMessage: String)(implicit F: Sync[F], ct: reflect.ClassTag[E]): F[Assertion] =
+      self.attempt.flatMap {
+        case Left(e: E) =>
+          if (e.getMessage == expectedMessage)
+            F.pure(Succeeded: Assertion)
+          else
+            F.delay(
+              fail(
+                s"Expected exception to have message '$expectedMessage' but got: ${e.getMessage}"
+              )
+            )
+        case Left(t) =>
+          F.delay(
+            fail(
+              s"Expected an exception of type ${ct.runtimeClass.getName} but got an exception: $t"
+            )
+          )
+        case Right(a) =>
+          F.delay(
+            fail(s"Expected an exception of type ${ct.runtimeClass.getName} but got a result: $a")
+          )
+      }
+
   }
 }

--- a/scalatest/shared/src/test/scala/cats/effect/testing/scalatest/IOTest.scala
+++ b/scalatest/shared/src/test/scala/cats/effect/testing/scalatest/IOTest.scala
@@ -38,6 +38,13 @@ class IOSpecTests extends AsyncFreeSpec with AsyncIOSpec with Matchers {
     "IO assert Exception" in {
       IO.raiseError(AError).assertThrows[AError.type]
     }
+
+    "IO assert Exception with message" in {
+      val expectedMessage = "foo"
+      IO.raiseError(AErrorWithMessage(expectedMessage))
+        .assertThrowsWithMessage[AErrorWithMessage](expectedMessage)
+    }
+
   }
 
   "Effect assertions" - {
@@ -60,3 +67,6 @@ class IOSpecTests extends AsyncFreeSpec with AsyncIOSpec with Matchers {
 }
 
 case object AError extends Throwable
+case class AErrorWithMessage(message: String) extends Throwable {
+  override def getMessage: String = message
+}


### PR DESCRIPTION
Add a scalatest assertion syntax for checking IO throws with an expected
error message.