### PR TITLE
Don't use default EC for scalatest

### DIFF
--- a/scalatest/shared/src/main/scala/cats/effect/testing/scalatest/AsyncIOSpec.scala
+++ b/scalatest/shared/src/main/scala/cats/effect/testing/scalatest/AsyncIOSpec.scala
@@ -27,8 +27,6 @@ import org.scalatest.time.Span
 
 trait AsyncIOSpec extends AssertingSyntax with EffectTestSupport with RuntimePlatform { asyncTestSuite: AsyncTestSuite =>
 
-  override implicit def executionContext = ioRuntime.compute
-
   implicit lazy val ioRuntime: IORuntime = IORuntime.global
 
   implicit def ioRetrying[T]: Retrying[IO[T]] = new Retrying[IO[T]] {

--- a/scalatest/shared/src/main/scala/cats/effect/testing/scalatest/AsyncIOSpec.scala
+++ b/scalatest/shared/src/main/scala/cats/effect/testing/scalatest/AsyncIOSpec.scala
@@ -27,7 +27,9 @@ import org.scalatest.time.Span
 
 trait AsyncIOSpec extends AssertingSyntax with EffectTestSupport with RuntimePlatform { asyncTestSuite: AsyncTestSuite =>
 
-  implicit lazy val ioRuntime: IORuntime = createIORuntime(executionContext)
+  override implicit def executionContext = ioRuntime.compute
+
+  implicit lazy val ioRuntime: IORuntime = IORuntime.global
 
   implicit def ioRetrying[T]: Retrying[IO[T]] = new Retrying[IO[T]] {
     override def retry(timeout: Span, interval: Span, pos: Position)(fun: => IO[T]): IO[T] =


### PR DESCRIPTION
ScalaTest uses a [`SerialExecutionContext`](https://github.com/scalatest/scalatest/blob/7aeda262e249a66d2319b6b2f5daa1b7d0cf9a4f/jvm/core/src/main/scala/org/scalatest/concurrent/SerialExecutionContext.scala#L32) by default, which can deadlock for async code. For those getting a sense of déjà vu, we already went through this with munit:
- https://github.com/scalameta/munit/pull/134#discussion_r560299293
- https://github.com/typelevel/munit-cats-effect/pull/65