### PR TITLE
Use Global EC for CatsResource

### DIFF
--- a/scalatest/js-native/src/main/scala/cats/effect/testing/scalatest/GlobalExecutionContext.scala
+++ b/scalatest/js-native/src/main/scala/cats/effect/testing/scalatest/GlobalExecutionContext.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.testing.scalatest
+
+import org.scalatest.FixtureAsyncTestSuite
+
+import scala.concurrent.ExecutionContext
+
+trait GlobalExecutionContext { this: FixtureAsyncTestSuite =>
+
+  override implicit def executionContext: ExecutionContext = scala.scalajs.concurrent.JSExecutionContext.queue
+
+}

--- a/scalatest/jvm/src/main/scala/cats/effect/testing/scalatest/GlobalExecutionContext.scala
+++ b/scalatest/jvm/src/main/scala/cats/effect/testing/scalatest/GlobalExecutionContext.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.testing.scalatest
+
+import org.scalatest.FixtureAsyncTestSuite
+
+import scala.concurrent.ExecutionContext
+
+trait GlobalExecutionContext { this: FixtureAsyncTestSuite =>
+
+  override implicit def executionContext: ExecutionContext = ExecutionContext.global
+
+}

--- a/scalatest/shared/src/main/scala/cats/effect/testing/scalatest/CatsResource.scala
+++ b/scalatest/shared/src/main/scala/cats/effect/testing/scalatest/CatsResource.scala
@@ -73,11 +73,18 @@ trait CatsResource[F[_], A] extends BeforeAndAfterAll { this: FixtureAsyncTestSu
   }
 
   override def afterAll(): Unit = {
-    UnsafeRun[F].unsafeToFuture(shutdown, finiteResourceTimeout)
-
-    gate = None
-    value = None
-    shutdown = ().pure[F]
+    UnsafeRun[F].unsafeToFuture(
+      for {
+        _ <- shutdown
+        _ <- Sync[F] delay {
+          gate = None
+          value = None
+          shutdown = ().pure[F]
+        }
+      } yield (),
+      finiteResourceTimeout
+    )
+    ()
   }
 
   override type FixtureParam = A

--- a/scalatest/shared/src/main/scala/cats/effect/testing/scalatest/CatsResource.scala
+++ b/scalatest/shared/src/main/scala/cats/effect/testing/scalatest/CatsResource.scala
@@ -24,7 +24,7 @@ import org.scalatest.{BeforeAndAfterAll, FixtureAsyncTestSuite, FutureOutcome, O
 
 import scala.concurrent.duration._
 
-trait CatsResource[F[_], A] extends BeforeAndAfterAll { this: FixtureAsyncTestSuite =>
+trait CatsResource[F[_], A] extends BeforeAndAfterAll with GlobalExecutionContext { this: FixtureAsyncTestSuite =>
 
   def ResourceAsync: Async[F]
   private[this] implicit def _ResourceAsync: Async[F] = ResourceAsync

--- a/scalatest/shared/src/main/scala/cats/effect/testing/scalatest/CatsResourceIO.scala
+++ b/scalatest/shared/src/main/scala/cats/effect/testing/scalatest/CatsResourceIO.scala
@@ -22,10 +22,12 @@ import cats.effect.unsafe.IORuntime
 
 import org.scalatest.FixtureAsyncTestSuite
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 
 trait CatsResourceIO[A] extends CatsResource[IO, A] with RuntimePlatform { this: FixtureAsyncTestSuite =>
+
+  override implicit def executionContext: ExecutionContext = ExecutionContext.global
 
   final def ResourceAsync = Async[IO]
 

--- a/scalatest/shared/src/main/scala/cats/effect/testing/scalatest/CatsResourceIO.scala
+++ b/scalatest/shared/src/main/scala/cats/effect/testing/scalatest/CatsResourceIO.scala
@@ -22,12 +22,10 @@ import cats.effect.unsafe.IORuntime
 
 import org.scalatest.FixtureAsyncTestSuite
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 import scala.concurrent.duration._
 
 trait CatsResourceIO[A] extends CatsResource[IO, A] with RuntimePlatform { this: FixtureAsyncTestSuite =>
-
-  override implicit def executionContext: ExecutionContext = ExecutionContext.global
 
   final def ResourceAsync = Async[IO]
 

--- a/scalatest/shared/src/test/scala/cats/effect/testing/scalatest/CatsResourceAllocationSpecs.scala
+++ b/scalatest/shared/src/test/scala/cats/effect/testing/scalatest/CatsResourceAllocationSpecs.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.testing.scalatest
+
+import cats.effect.{IO, Resource}
+import org.scalatest.concurrent.Eventually
+import org.scalatest.events.Event
+import org.scalatest.{Args, Reporter}
+import org.scalatest.matchers.must.Matchers._
+import org.scalatest.wordspec.{AsyncWordSpec, FixtureAsyncWordSpec}
+
+import scala.concurrent.duration._
+
+class CatsResourceAllocationSpecs extends AsyncWordSpec with Eventually {
+
+  override implicit def patienceConfig: PatienceConfig =
+    super.patienceConfig.copy(timeout = 1.second)
+
+  @volatile
+  var beforeCalled: Int = 0
+
+  @volatile
+  var afterCalled: Int = 0
+
+  class ResourceSpec
+      extends FixtureAsyncWordSpec
+      with AsyncIOSpec
+      with CatsResourceIO[Unit] {
+
+    override val resource: Resource[IO, Unit] =
+      Resource.make { IO.delay { beforeCalled += 1 } } { _ =>
+        IO.delay { afterCalled += 1 }
+      }
+
+    "test" should {
+      "doFoo" in { _ => true mustBe true }
+    }
+  }
+
+  val reporter: Reporter = (_: Event) => ()
+
+  "cats resource allocation" should {
+    "release the resource" in {
+
+      val outerResourceSpec = new ResourceSpec
+
+      outerResourceSpec.run(None, Args(reporter))
+
+      eventually {
+        beforeCalled mustBe 1
+        afterCalled mustBe 1
+      }
+    }
+  }
+}


### PR DESCRIPTION
Attempts to fix https://github.com/typelevel/cats-effect-testing/issues/300

Loosely based on https://github.com/scalatest/scalatest/blob/310197b73d61f832bdfc4f7c939dbfa689057c54/jvm/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterAllSpec.scala#L76