### PR TITLE
Tweak Specs2 CatsResource to rethrow exceptions raised during resource acquisition

### DIFF
--- a/specs2/shared/src/test/scala/cats/effect/testing/specs2/CatsResourceErrorSpecs.scala
+++ b/specs2/shared/src/test/scala/cats/effect/testing/specs2/CatsResourceErrorSpecs.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.testing.specs2
+
+import cats.effect.{IO, Resource}
+import org.specs2.execute.Result
+import org.specs2.mutable.SpecificationLike
+
+case class BlowUpResourceException() extends RuntimeException("boom")
+
+class CatsResourceErrorSpecs
+  extends CatsResource[IO, Unit]
+    with SpecificationLike {
+
+  private val expectedException = BlowUpResourceException()
+
+  val resource: Resource[IO, Unit] =
+    Resource.eval(IO.raiseError(expectedException))
+
+  "cats resource support" should {
+    "report failure when the resource acquisition fails" in withResource[Result] { _ =>
+      IO(failure("we shouldn't get here if an exception was raised"))
+    }
+      .recover[Result] {
+        case ex: RuntimeException =>
+          ex must beEqualTo(expectedException)
+      }
+  }
+}


### PR DESCRIPTION
Basically, if an exception is raised when acquiring the `val resource: Resource[F, A]`, it would previously be swallowed by the Future launched by `beforeAll`. Due to the exception, the gate is never closed (i.e., the `Deferred` is never completed), so the `Deferred#get` call in `withResource` never completes. 

This PR puts a timeout on the `Deferred#get` call in `withResource` to avoid waiting forever. It also updates `var value` to maybe contain `Either[Throwable, A]`, so that the exception raised in the acquisition phase is raised in the test, so that the user can see the details of the exception and hopefully resolve the underlying issue.