### PR TITLE
Make ScalaTest's CatsResource beforeAll and afterAll methods protected

### DIFF
--- a/scalatest/shared/src/main/scala/cats/effect/testing/scalatest/CatsResource.scala
+++ b/scalatest/shared/src/main/scala/cats/effect/testing/scalatest/CatsResource.scala
@@ -50,7 +50,7 @@ trait CatsResource[F[_], A] extends BeforeAndAfterAll { this: FixtureAsyncTestSu
   @volatile
   private var shutdown: F[Unit] = ().pure[F]
 
-  override def beforeAll(): Unit = {
+  override protected def beforeAll(): Unit = {
     val toRun = for {
       d <- Deferred[F, Unit]
       _ <- Sync[F] delay {
@@ -72,7 +72,7 @@ trait CatsResource[F[_], A] extends BeforeAndAfterAll { this: FixtureAsyncTestSu
     ()
   }
 
-  override def afterAll(): Unit = {
+  override protected def afterAll(): Unit = {
     UnsafeRun[F].unsafeToFuture(shutdown, finiteResourceTimeout)
 
     gate = None

--- a/scalatest/shared/src/main/scala/cats/effect/testing/scalatest/CatsResource.scala
+++ b/scalatest/shared/src/main/scala/cats/effect/testing/scalatest/CatsResource.scala
@@ -51,6 +51,8 @@ trait CatsResource[F[_], A] extends BeforeAndAfterAll { this: FixtureAsyncTestSu
   private var shutdown: F[Unit] = ().pure[F]
 
   override protected def beforeAll(): Unit = {
+    super.beforeAll()
+
     val toRun = for {
       d <- Deferred[F, Unit]
       _ <- Sync[F] delay {
@@ -68,8 +70,7 @@ trait CatsResource[F[_], A] extends BeforeAndAfterAll { this: FixtureAsyncTestSu
       _ <- d.complete(())
     } yield ()
 
-    UnsafeRun[F].unsafeToFuture(toRun, finiteResourceTimeout)
-    ()
+    val _ = UnsafeRun[F].unsafeToFuture(toRun, finiteResourceTimeout)
   }
 
   override protected def afterAll(): Unit = {
@@ -78,6 +79,8 @@ trait CatsResource[F[_], A] extends BeforeAndAfterAll { this: FixtureAsyncTestSu
     gate = None
     value = None
     shutdown = ().pure[F]
+
+    super.afterAll()
   }
 
   override type FixtureParam = A


### PR DESCRIPTION
This syncs them with the original definition and avoids compiler errors when other things that use `BeforeAndAfterAll` are mixed in.

```scala
[error] file.scala:31:7: weaker access privileges in overriding
[error] override def afterAll(): Unit (defined in trait CatsResource)
[error]   override should be public
```

I'm not sure if this has MiMa implications; when I ran it locally I did get a couple errors, but I didn't see them in the builds in our GHAs. We'll see what happens in this PR.