### PR TITLE
bump native deps

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,8 +26,8 @@ ThisBuild / tlVersionIntroduced := Map("3" -> "1.1.1")
 
 ThisBuild / tlCiReleaseBranches := Seq("series/1.x")
 
-val CatsEffectVersion = "3.6.0"
-val ScalaTestVersion = "3.2.18"
+val CatsEffectVersion = "3.7-4972921"
+val ScalaTestVersion = "3.2.19"
 
 lazy val root = tlCrossRootProject
   .aggregate(core, specs2, utest, minitest, scalatest)
@@ -45,7 +45,7 @@ lazy val specs2 = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .dependsOn(core)
   .settings(
     name := "cats-effect-testing-specs2",
-    libraryDependencies += "org.specs2" %%% "specs2-core" % "4.20.5")
+    libraryDependencies += "org.specs2" %%% "specs2-core" % "4.21.0")
   .nativeSettings(tlVersionIntroduced := List("2.12", "2.13", "3").map(_ -> "1.5.0").toMap)
 
 lazy val scalatest = crossProject(JSPlatform, JVMPlatform, NativePlatform)
@@ -72,7 +72,7 @@ lazy val utest = crossProject(JSPlatform, JVMPlatform, NativePlatform)
 
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "cats-effect-testkit" % CatsEffectVersion,
-      "com.lihaoyi" %%% "utest" % "0.8.2"),
+      "com.lihaoyi" %%% "utest" % "0.8.5"),
 
     Test / scalacOptions -= "-Xfatal-warnings")
   .nativeSettings(tlVersionIntroduced := List("2.12", "2.13", "3").map(_ -> "1.5.0").toMap)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.7.7")
-addSbtPlugin("org.scala-js"  % "sbt-scalajs"   % "1.18.2")
-addSbtPlugin("org.scala-native"   % "sbt-scala-native" % "0.4.17")
+addSbtPlugin("org.scala-js"  % "sbt-scalajs"   % "1.19.0")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native" % "0.5.6")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")


### PR DESCRIPTION
I wanted to test some scala-native cats-effect code, which currently appears to be using scala.native 0.5.6. I bumped the various dependencies until local publishing worked - this mostly works except that there appears to be a dependency conflict with utest. 